### PR TITLE
Categorical ref name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,3 @@ sample_data/transcriptome_collapsed.bam.bai
 sample_data/gencode.v25.annotation.gff3 
 *.csv
 
-test.png

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ sample_data/transcriptome_collapsed.bam.bai
 sample_data/gencode.v25.annotation.gff3 
 *.csv
 
+test.png

--- a/RiboMetric/file_parser.py
+++ b/RiboMetric/file_parser.py
@@ -164,6 +164,7 @@ def parse_bam(bam_file: str, num_reads: int) -> pd.DataFrame:
                                     read_list,
                                     columns=read_df.columns)
                                  ])
+
             read_df_length = len(read_df)
             counter = 0
             read_list = []
@@ -180,7 +181,8 @@ def parse_bam(bam_file: str, num_reads: int) -> pd.DataFrame:
                 end="\r",
             )
 
-    process.kill()
+    process.kill()  
+    read_df["reference_name"] = read_df["reference_name"].astype("category")
     return read_df
 
 

--- a/RiboMetric/modules.py
+++ b/RiboMetric/modules.py
@@ -322,9 +322,10 @@ def annotate_reads(
         with an added column for the a-site location along
         with the columns from the gff file
     """
-    annotated_read_df = a_site_df.assign(
+    annotated_read_df = a_site_df.drop("sequence", axis=1).assign(
         transcript_id=a_site_df.reference_name.str.split("|").str[0]
     ).merge(annotation_df, on="transcript_id")
+    annotated_read_df["transcript_id"] = annotated_read_df["transcript_id"].astype("category")
     return annotated_read_df
 
 
@@ -361,6 +362,8 @@ def assign_mRNA_category(annotated_read_df) -> str:
         choices,
         "unknown"
         )
+    annotated_read_df["mRNA_category"] = \
+        annotated_read_df["mRNA_category"].astype("category")
     return annotated_read_df
 
 


### PR DESCRIPTION
Setting reference name, trancript_id and mRNA category to dtype 'category' improves memory usage. Before and after:
![lukasdev1](https://github.com/JackCurragh/RiboMetric/assets/118811454/55dd340d-6bd0-41db-9891-2aa2efec11cf)
Highest peak: **2500** MiB
![categorical1](https://github.com/JackCurragh/RiboMetric/assets/118811454/8e496fbb-bf3b-4687-977b-251eb1730f96)
Highest peak: **1750** MiB
_Plots created with [memory profiler](https://pypi.org/project/memory-profiler/) for default 'RiboMetrics run' with annotation._
