### PR TITLE
Relative counts heatmap

### DIFF
--- a/RiboMetric/RiboMetric.py
+++ b/RiboMetric/RiboMetric.py
@@ -208,7 +208,8 @@ def main(args):
             bam_results = parse_bam(
                 bam_file=config["argument"]["bam"],
                 num_reads=read_limit,
-                num_processes=config["argument"]["threads"],)
+                num_processes=config["argument"]["threads"],
+                server_mode=config["argument"]["server"])
 
             read_df_pre = bam_results[0]
             sequence_data = bam_results[1]
@@ -283,7 +284,7 @@ def main(args):
                 filename = filename.split('.')[:-1]
 
         elif config["argument"]["json_in"]:
-
+            print("JSON input provided")
             filename = config["argument"]["json_in"].split('/')[-1]
             if "." in filename:
                 filename = filename.split('.')[:-1]

--- a/RiboMetric/arg_parser.py
+++ b/RiboMetric/arg_parser.py
@@ -75,6 +75,12 @@ def argument_parser():
         help="Use JSON config instead of active config for generating plots",
     )
     run_parser.add_argument(
+        "--server",
+        action="store_true",
+        default=False,
+        help="Runs RiboMetric in 'server' mode, higher speed at cost of memory efficiency",
+    )
+    run_parser.add_argument(
         "-n",
         "--name",
         type=str,
@@ -211,9 +217,6 @@ def open_config(args) -> dict:
 
         with open(config_file_path, "r") as yml:
             config = yaml.load(yml, Loader=yaml.Loader)
-
-    for arg in vars(args):
-        print(f"{arg}: {getattr(args, arg)}")
 
     if args.command == "run" and args.all:
         args.json = True

--- a/RiboMetric/bam_processing.py
+++ b/RiboMetric/bam_processing.py
@@ -91,6 +91,7 @@ def ox_server_parse_reads(bam_file: str,
     oxbow_df = pyarrow.ipc.open_file(io.BytesIO(arrow_ipc)).read_pandas()
     del arrow_ipc
     read_df = process_reads(oxbow_df)
+    print("retrieving sequence data")
     sequence_data = {1: [], 2: []}
     sequence_list = oxbow_df["seq"].tolist()
     count_list = read_df["count"].tolist()
@@ -402,7 +403,6 @@ def get_batch_data(
         full_sequence_batches = [sequence_data]
         for pattern_length in bam_batches[1].keys():
             sequence_data[pattern_length] = [result.get() for result in bam_batches[1][pattern_length]]
-            print(full_sequence_batches)
 
     else:
         bam_tuples = [result.get() for result in bam_batches]

--- a/RiboMetric/bam_processing.py
+++ b/RiboMetric/bam_processing.py
@@ -8,24 +8,26 @@ import oxbow as ox
 import io
 import pyarrow.ipc
 from .bam_splitting import split_bam
+from multiprocessing import Pool
 
 
 def ox_parse_reads(bam_file: str,
                    split_num: int,
                    reference_df: pd.DataFrame,
-                   tempdir: str) -> tuple:
+                   tempdir: str
+) -> tuple:
     """
     Splits a bam files using generated bed files, uses oxbow to process these
     batches of reads directly into a data frame and then processes the data
     from this generated dataframe into read and sequence data
 
-    Args:
+    Inputs:
         bam_file: Path to the BAM file
         split_num: Number of the split
         reference_df: Reference dataframe, generated from samtools idxstats
         tempdir: Path to the temporary directory
 
-    Returns:
+    Outputs:
         tuple: A tuple containing:
             batch_df: Dataframe containing a processed batch of reads
             sequence_data: Dictionary containing the processed sequence data
@@ -45,6 +47,7 @@ def ox_parse_reads(bam_file: str,
     sequence_data = {1: [], 2: []}
     sequence_list = oxbow_df["seq"].tolist()
     count_list = batch_df["count"].tolist()
+    # sequence_list batch size
     size = 10000
     if len(sequence_list) < size and len(sequence_list) != 0:
         size = len(sequence_list)
@@ -62,6 +65,59 @@ def ox_parse_reads(bam_file: str,
                                   pattern_length))
 
     return (batch_df, sequence_data)
+
+
+def ox_server_parse_reads(bam_file: str,
+                          num_processes: int= 4
+) -> tuple:
+    """
+    Functionally the same as ox_parse_reads,
+    but without splitting the bam file.
+
+    Inputs:
+        bam_file: Path to the BAM file
+        pool: Multiprocessing pool
+
+    Outputs:
+        tuple: A tuple containing:
+            batch_df: Dataframe containing a processed batch of reads
+            sequence_data: Dictionary containing the processed sequence data
+    """
+    pool = Pool(processes=num_processes)
+    print("Running in server mode")
+    print("Generating pyarrow object")
+    arrow_ipc = ox.read_bam(bam_file)
+    print("Transforming to pandas df")
+    oxbow_df = pyarrow.ipc.open_file(io.BytesIO(arrow_ipc)).read_pandas()
+    del arrow_ipc
+    read_df = process_reads(oxbow_df)
+    sequence_data = {1: [], 2: []}
+    sequence_list = oxbow_df["seq"].tolist()
+    count_list = read_df["count"].tolist()
+    del oxbow_df
+    # sequence_list batch size
+    size = 10000
+    if len(sequence_list) < size and len(sequence_list) != 0:
+        size = len(sequence_list)
+    for pattern_length in sequence_data:
+        count = -1
+        for i in range(0, len(sequence_list), size):
+            count += 1
+            if count % 10 != 0:
+                continue
+            section = sequence_list[i:i+size]
+            counts = count_list[i:i+size]
+            sequence_data[pattern_length].append(
+                pool.apply_async(
+                    process_sequences,
+                    [section, counts, pattern_length]
+                    )
+                )
+            
+    pool.close()
+    pool.join()
+
+    return (read_df, sequence_data)
 
 
 def process_reads(oxbow_df: pd.DataFrame) -> pd.DataFrame:
@@ -340,10 +396,19 @@ def get_batch_data(
             background_batches: Dictionary containing background data
             sequence_batches: Dictionary containing sequence data
     """
-    bam_tuples = [result.get() for result in bam_batches]
+    if type(bam_batches[0]) == pd.DataFrame:
+        read_batches = [bam_batches[0]]
+        sequence_data = {}
+        full_sequence_batches = [sequence_data]
+        for pattern_length in bam_batches[1].keys():
+            sequence_data[pattern_length] = [result.get() for result in bam_batches[1][pattern_length]]
+            print(full_sequence_batches)
 
-    read_batches = [data[0] for data in bam_tuples]
-    full_sequence_batches = [data[1] for data in bam_tuples]
+    else:
+        bam_tuples = [result.get() for result in bam_batches]
+
+        read_batches = [data[0] for data in bam_tuples]
+        full_sequence_batches = [data[1] for data in bam_tuples]
 
     background_batches, sequence_batches = {}, {}
     for pattern_length in full_sequence_batches[0].keys():

--- a/RiboMetric/bam_processing.py
+++ b/RiboMetric/bam_processing.py
@@ -61,8 +61,6 @@ def ox_parse_reads(bam_file: str,
                                   counts,
                                   pattern_length))
 
-        print(f"> {split_num}: pattern length {pattern_length}, "
-              "done in {datetime.now()-t1}")
     return (batch_df, sequence_data)
 
 

--- a/RiboMetric/bam_splitting.py
+++ b/RiboMetric/bam_splitting.py
@@ -36,7 +36,7 @@ def run_samtools_idxstats(bam_file: str) -> pd.DataFrame:
 
 
 def split_idxstats_df(idxstats_df: pd.DataFrame,
-                      max_reads: int,
+                      batch_size: int,
                       num_reads: int) -> list:
     """
     Split the idxstats data frame into a list of data frames limited to
@@ -45,7 +45,7 @@ def split_idxstats_df(idxstats_df: pd.DataFrame,
 
     Inputs:
         idxstats_df: Results from samtools idxstats
-        max_reads: Maximum number of reads in a batch
+        batch_size: Maximum number of reads in a batch
         num_reads: Number of reads to parse
 
     Outputs:
@@ -63,9 +63,9 @@ def split_idxstats_df(idxstats_df: pd.DataFrame,
 
     for i in range(len(mapped_reads)):
         reads = mapped_reads[i] + unmapped_reads[i]
-        if current_sum + reads <= max_reads:
+        if current_sum + reads <= batch_size:
             current_sum += reads
-            if (current_sum + (split_num * max_reads)) > num_reads:
+            if (current_sum + (split_num * batch_size)) > num_reads:
                 break
         else:
             current_df = idxstats_df.iloc[last_index:i, [0, 1]].copy()

--- a/RiboMetric/config.yml
+++ b/RiboMetric/config.yml
@@ -6,6 +6,7 @@ argument:
   fasta: null                 # Filepath for fasta
   json_in: null               # Filepath for JSON input
   json_config: False          # Use JSON config instead of this config for generating plots
+  server: False               # If true, runs 'server' mode, uses more memory, but runs faster
   name: null                  # Sets the name for the reports and/or data output, when set to None, uses bam filename
   output: "."                 # Sets the output directory for the reports and/or data output
   threads: 8                  # Number of threads used by RiboMetric

--- a/RiboMetric/config.yml
+++ b/RiboMetric/config.yml
@@ -45,9 +45,9 @@ plots:
   metagene_profile:
     distance_target: "both"   # Options: ["start", "stop", "both"]
     shared_yaxis: False       # For the metagene profile barplot, controls whether the start and stop distance share a y-axis or not
-    distance_range: [-30,30]
+    distance_range: [-30,30]  # Set the max distance to count reads from the target(s)
     colorscale: "electric"    # Heatmap colorscale, see https://plotly.com/python/builtin-colorscales/
-    max_colorscale: null       # set to null for automatic maximum
+    max_colorscale: null      # if set to null, the plot will generate with relative counts (0 to 1)
     
 qc:
   use_cds_subset:

--- a/RiboMetric/config.yml
+++ b/RiboMetric/config.yml
@@ -1,5 +1,5 @@
-# Arguments, overwritten when called in the command-line
 argument:
+  # Arguments, config values are overwritten when called in the command-line
   bam: null                   # Filepath for bam
   annotation: null            # Filepath for annotation
   gff: null                   # Filepath for gff

--- a/RiboMetric/file_parser.py
+++ b/RiboMetric/file_parser.py
@@ -151,6 +151,7 @@ def parse_bam(bam_file: str,
             parsed_bam = join_batches(bam_batches)
 
     else:
+        print("Warning: The server option is not working as intended. Regular runs are recommended.")
         bam_batches = ox_server_parse_reads(bam_file)
         parsed_bam = join_batches(bam_batches)
 

--- a/RiboMetric/file_parser.py
+++ b/RiboMetric/file_parser.py
@@ -15,7 +15,7 @@ from multiprocessing import Pool
 from tempfile import TemporaryDirectory
 
 
-from .bam_processing import join_batches, ox_parse_reads
+from .bam_processing import join_batches, ox_parse_reads, ox_server_parse_reads
 from .bam_splitting import run_samtools_idxstats, split_idxstats_df
 
 
@@ -103,10 +103,11 @@ def flagstat_bam(bam_path: str) -> dict:
     return flagstat_dict
 
 
-def parse_bam(bam_file,
-              num_reads,
-              batch_size=10000000,
-              num_processes=4
+def parse_bam(bam_file: str,
+              num_reads: int,
+              batch_size: int=10000000,
+              num_processes: int=4,
+              server_mode: bool=False,
               ) -> tuple:
     """
     Read in the bam file at the provided path and return parsed read and
@@ -129,23 +130,30 @@ def parse_bam(bam_file,
                                 frequency of nucleotide patterns for five and
                                 three prime
     """
-    pool = Pool(processes=num_processes)
-    bam_batches = []
-    with TemporaryDirectory() as tempdir:
-        idxstats_df = run_samtools_idxstats(bam_file)
-        reference_dfs = split_idxstats_df(idxstats_df,
-                                          batch_size,
-                                          num_reads)
-        for split_num, reference_df in enumerate(reference_dfs):
-            bam_batches.append(pool.apply_async(ox_parse_reads,
-                                                [bam_file,
-                                                 split_num,
-                                                 reference_df,
-                                                 tempdir]))
-        pool.close()
-        pool.join()
+    if server_mode is False:
+        pool = Pool(processes=num_processes)
+        bam_batches = []
+        with TemporaryDirectory() as tempdir:
+            idxstats_df = run_samtools_idxstats(bam_file)
+            reference_dfs = split_idxstats_df(idxstats_df,
+                                            batch_size,
+                                            num_reads)
+            for split_num, reference_df in enumerate(reference_dfs):
+                bam_batches.append(pool.apply_async(ox_parse_reads,
+                                                    [bam_file,
+                                                    split_num,
+                                                    reference_df,
+                                                    tempdir]))
 
-    parsed_bam = join_batches(bam_batches)
+            pool.close()
+            pool.join()
+
+            parsed_bam = join_batches(bam_batches)
+
+    else:
+        bam_batches = ox_server_parse_reads(bam_file)
+        parsed_bam = join_batches(bam_batches)
+
 
     return parsed_bam
 

--- a/RiboMetric/file_parser.py
+++ b/RiboMetric/file_parser.py
@@ -130,6 +130,11 @@ def parse_bam(bam_file: str,
                                 frequency of nucleotide patterns for five and
                                 three prime
     """
+    batch_size = int((num_reads/num_processes)*1.02)
+    # Small percentage increase to ensure remaining reads aren't
+    # in separate batch
+
+    print(f"Splitting BAM into {batch_size} reads")
     if server_mode is False:
         pool = Pool(processes=num_processes)
         bam_batches = []

--- a/RiboMetric/modules.py
+++ b/RiboMetric/modules.py
@@ -484,23 +484,27 @@ removing boundaries..."
                 .size()
                 .to_dict()
             )
-        # Fill empty read length and distance keys with None
+        # Fill empty read lengths with 0
         min_length = min([x[0] for x in list(pre_metaprofile_dict.keys())])
         max_length = max([x[0] for x in list(pre_metaprofile_dict.keys())])
         for y in range(min_length, max_length):
             if y not in [x[0] for x in list(pre_metaprofile_dict.keys())]:
-                pre_metaprofile_dict[(y, 0)] = None
+                pre_metaprofile_dict[(y, 0)] = 0
 
-        min_distance = min([x[1] for x in list(pre_metaprofile_dict.keys())])
-        max_distance = max([x[1] for x in list(pre_metaprofile_dict.keys())])
-        for z in range(min_distance, max_distance):
-            if z not in [x[1] for x in list(pre_metaprofile_dict.keys())]:
-                pre_metaprofile_dict[(min_length, z)] = None
+        neg_distance = min([x[1] for x in list(pre_metaprofile_dict.keys())])
+        pos_distance = max([x[1] for x in list(pre_metaprofile_dict.keys())])
+        position_range = range(neg_distance, pos_distance+1)
 
         for key, value in pre_metaprofile_dict.items():
             if key[0] not in metagene_profile_dict[current_target]:
                 metagene_profile_dict[current_target][key[0]] = {}
             metagene_profile_dict[current_target][key[0]][key[1]] = value
+
+        # Fill empty distances with 0
+        for position_dict in metagene_profile_dict[current_target].values():
+            for position in position_range:
+                position_dict.setdefault(position, 0)
+
     return metagene_profile_dict
 
 

--- a/RiboMetric/modules.py
+++ b/RiboMetric/modules.py
@@ -485,14 +485,14 @@ removing boundaries..."
                 .to_dict()
             )
         # Fill empty read lengths with 0
-        min_length = min([x[0] for x in list(pre_metaprofile_dict.keys())])
-        max_length = max([x[0] for x in list(pre_metaprofile_dict.keys())])
+        min_length = int(min([x[0] for x in list(pre_metaprofile_dict.keys())]))
+        max_length = int(max([x[0] for x in list(pre_metaprofile_dict.keys())]))
         for y in range(min_length, max_length):
             if y not in [x[0] for x in list(pre_metaprofile_dict.keys())]:
                 pre_metaprofile_dict[(y, 0)] = 0
 
-        neg_distance = min([x[1] for x in list(pre_metaprofile_dict.keys())])
-        pos_distance = max([x[1] for x in list(pre_metaprofile_dict.keys())])
+        neg_distance = int(min([x[1] for x in list(pre_metaprofile_dict.keys())]))
+        pos_distance = int(max([x[1] for x in list(pre_metaprofile_dict.keys())]))
         position_range = range(neg_distance, pos_distance+1)
 
         for key, value in pre_metaprofile_dict.items():

--- a/RiboMetric/plots.py
+++ b/RiboMetric/plots.py
@@ -743,7 +743,8 @@ def plot_metagene_heatmap(metagene_profile_dict: dict, config: dict) -> dict:
                 z_data.append(v2)
 
         if config["plots"]["metagene_profile"]["max_colorscale"] is None:
-            z_data = [z/max(z_data) for z in z_data]
+            z_max = max(z_data)
+            z_data = [z/z_max for z in z_data]
 
         fig.add_trace(
             go.Heatmap(

--- a/RiboMetric/plots.py
+++ b/RiboMetric/plots.py
@@ -729,6 +729,9 @@ def plot_metagene_heatmap(metagene_profile_dict: dict, config: dict) -> dict:
                 y_data.append(k1)
                 z_data.append(v2)
 
+        if config["plots"]["metagene_profile"]["max_colorscale"] is None:
+            z_data = [z/max(z_data) for z in z_data]
+
         fig.add_trace(
             go.Heatmap(
                 x=x_data,
@@ -741,12 +744,15 @@ def plot_metagene_heatmap(metagene_profile_dict: dict, config: dict) -> dict:
             row=1,
             col=count,
         )
-    fig.update_xaxes(
-        range=config["plots"]["metagene_profile"]["distance_range"]
-    )
+        fig.update_xaxes(
+            title_text="Relative position (nt)",
+            row=1,
+            col=count,
+            title_font=dict(size=18),
+            range=config["plots"]["metagene_profile"]["distance_range"]
+        )
     fig.update_layout(
         title="Metagene Heatmap",
-        xaxis_title="Relative position (nt)",
         yaxis_title="Read length",
         font=dict(
             family=config["plots"]["font_family"],

--- a/RiboMetric/plots.py
+++ b/RiboMetric/plots.py
@@ -173,10 +173,17 @@ def plot_ligation_bias_distribution(
             row=1,
             col=count,
         )
+
         fig.add_hline(y=0)
+
+        fig.update_xaxes(
+            title_text="Read Start",
+            row=1,
+            col=count,
+            title_font=dict(size=18)
+        )
     fig.update_layout(
         title="Ligation Bias Distribution",
-        xaxis_title="Read Start",
         yaxis_title="Proportion",
         font=dict(
             family=config["plots"]["font_family"],
@@ -641,10 +648,16 @@ def plot_metagene_profile(metagene_profile_dict: dict, config: dict) -> dict:
             row=1,
             col=count,
         )
+        fig.update_xaxes(
+            title_text="Relative position (nt)",
+            row=1,
+            col=count,
+            title_font=dict(size=18),
+            range=config["plots"]["metagene_profile"]["distance_range"]
+        )
 
     fig.update_layout(
         title="Metagene Profile",
-        xaxis_title="Relative position",
         yaxis_title="Read Count",
         font=dict(
             family=config["plots"]["font_family"],

--- a/tests/test_RiboMetric.py
+++ b/tests/test_RiboMetric.py
@@ -47,7 +47,7 @@ def test_main_run():
         fasta=None,
         subsample=1000,
         transcripts=None,
-        json=None,
+        json=True,
         html=True,
         pdf=None,
         csv=None,
@@ -64,3 +64,69 @@ def test_main_run():
     # Assert that the expected output was produced
     assert 'Annotation parsed' in output
     assert 'Running modules' in output
+
+
+def test_main_run_server():
+    file_path = os.path.join(os.path.dirname(__file__), "test_data")
+    print(file_path)
+    args = Namespace(
+        command="run",
+        annotation=f"{file_path}/1000_entry_RiboMetric.tsv",
+        bam=f"{file_path}/test.bam",
+        output=f"{file_path}",
+        config=f"{file_path}/../../config.yml",
+        all=False,
+        gff=None,
+        fasta=None,
+        subsample=1000,
+        transcripts=None,
+        json=None,
+        html=None,
+        pdf=None,
+        csv=True,
+        server=True
+    )
+
+    # Redirect stdout to a StringIO object to capture output
+    sys.stdout = StringIO()
+
+    main(args)
+
+    # Get the output
+    output = sys.stdout.getvalue()
+
+    # Assert that the expected output was produced
+    assert 'Annotation parsed' in output
+    assert 'Running modules' in output
+
+
+def test_main_run_json():
+    file_path = os.path.join(os.path.dirname(__file__), "test_data")
+    print(file_path)
+    args = Namespace(
+        command="run",
+        json_in=f"{file_path}/test.json",
+        output=f"{file_path}",
+        config=f"{file_path}/../../config.yml",
+        all=False,
+        gff=None,
+        fasta=None,
+        subsample=1000,
+        transcripts=None,
+        json=None,
+        html=None,
+        pdf=True,
+        csv=None,
+    )
+
+    # Redirect stdout to a StringIO object to capture output
+    sys.stdout = StringIO()
+
+    main(args)
+
+    # Get the output
+    output = sys.stdout.getvalue()
+
+    # Assert that the expected output was produced
+    assert 'JSON' in output
+    assert 'Your pdf report can be found' in output


### PR DESCRIPTION
This branch got a bit bigger than intended with the inclusion of server mode.
Sadly, it seems server mode doesn't seem to do any better than the regular mode (tested with ~70M reads):
regular mode | server mode
--- | ---
![regular_mode](https://github.com/JackCurragh/RiboMetric/assets/118811454/089ec8c3-3323-41b1-b158-9854f79c8b83) | ![server_mode](https://github.com/JackCurragh/RiboMetric/assets/118811454/019dd518-51a9-461c-bde2-5094ef5cc3cc) 

Peak memory usage is unchanged (the modules have oxbow beat there), but time actually increases due. The steady incline at the start (0-250s) is the pyarrow object being created, the file is being read into memory. The unstable part that follows (250-400s) is the pyarrow object being converted to a pandas df. The last step in parsing is the flat valley of sequence parsing (400-600s), bringing the total time to parse the file up to 10 minutes (from 5 minutes, it took twice as long!). As extra information, the following plateau is the merging of annotation and reads.

So I'm not sure if we can improve the speed at the cost of memory for servers like this. Maybe improvements can be made by changing the batch size?

P.S.: Server mode also currently lacks the option for only getting a certain number of reads.